### PR TITLE
Fix segfault when testing NULL pointer with expected string + update assert_ to take long instead of ints.

### DIFF
--- a/ctest.h
+++ b/ctest.h
@@ -98,7 +98,7 @@ void assert_str(const char* exp, const char*  real, const char* caller, int line
 void assert_equal(long exp, long real, const char* caller, int line);
 #define ASSERT_EQUAL(exp, real) assert_equal(exp, real, __FILE__, __LINE__)
 
-void assert_not_equal(int exp, int real, const char* caller, int line);
+void assert_not_equal(long exp, long real, const char* caller, int line);
 #define ASSERT_NOT_EQUAL(exp, real) assert_not_equal(exp, real, __FILE__, __LINE__)
 
 void assert_null(void* real, const char* caller, int line);
@@ -231,9 +231,9 @@ void assert_equal(long exp, long real, const char* caller, int line) {
     }
 }
 
-void assert_not_equal(int exp, int real, const char* caller, int line) {
+void assert_not_equal(long exp, long real, const char* caller, int line) {
     if ((exp) == (real)) {
-        CTEST_ERR("%s:%d  should not be %d", caller, line, real);
+        CTEST_ERR("%s:%d  should not be %ld", caller, line, real);
         longjmp(ctest_err, 1);
     }
 }

--- a/mytests.c
+++ b/mytests.c
@@ -154,3 +154,9 @@ CTEST(ctest, test_string_diff_ptrs) {
     const char *str = "abc\0abc";
     ASSERT_STR(str, str+4);
 }
+
+CTEST(ctest, test_large_numbers) {
+    long exp = 7200000000;
+    ASSERT_EQUAL(exp, 7200000000);
+    ASSERT_NOT_EQUAL(exp, 1200000000);
+}


### PR DESCRIPTION
- ctest.h
  (assert_str): Check for NULL-pointers before invoking strcmp.
- mytests.c
  (test_null_null, test_null_string,
  test_string_null, test_string_diff_ptrs): Add some new tests.
