### PR TITLE
MikroC compiler support and minor features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ UNAME=$(shell uname)
 
 CCFLAGS=-Wall -Wextra -Wno-unused-parameter -O3
 ifdef CTEST_COLOR_OK
-CCFLAGS+=-DCOLOR_OK
+CCFLAGS+=-DCTEST_COLOR_OK
 endif
 
 ifeq ($(UNAME), Darwin)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ CCFLAGS=-Wall -Wextra -Wno-unused-parameter -O3
 ifdef CTEST_COLOR_OK
 CCFLAGS+=-DCTEST_COLOR_OK
 endif
+ifdef CTEST_MORE_COLORS
+CCFLAGS+=-DCTEST_MORE_COLORS
+endif
 
 ifeq ($(UNAME), Darwin)
 LDFLAGS=-Wl,-flat_namespace,-undefined,dynamic_lookup

--- a/README
+++ b/README
@@ -115,3 +115,7 @@ Configuration macros:
  * CTEST_COLOR_OK
 
    Colorize 'OK' messages.
+
+ * CTEST_MORE_COLORS
+
+   Even more colors.

--- a/README
+++ b/README
@@ -39,7 +39,7 @@ TEST 2/2 suite1:test2 [FAIL]
 RESULTS: 2 tests (1 ok, 1 failed, 0 skipped) ran in 1 ms
 
 There can be one argument to: ./test <suite>.
-for example: 
+for example:
 $ ./test timer
 will run all tests from suites starting with 'timer'
 
@@ -79,3 +79,39 @@ tests, but not run. To skip a test add _SKIP:
 
 CTEST_SKIP(..)    or CTEST2_SKIP(..)
 
+----------------------------------------------------------------------------
+Configuration macros:
+
+ * CTEST_MAIN
+
+   If defined, ctest_main() implementation will be included.
+
+ * CTEST_USER_TIME
+
+   If defined, this macro will be used to retreive current time in milliseconds,
+   instead of using gettimeofday().
+
+ * CTEST_USER_PRINTF
+
+   If defined, this macro will be used instead of printf().
+
+ * CTEST_USER_FLUSH
+
+   If defined, this macro will be used instead of fflush(stdout).
+
+ * CTEST_ADD_TESTS_MANUALLY
+
+   If defined, test should be added manually using macros:
+      CTEST_ADD(suite, test);    // for CTEST
+      CTEST_ADD2(suite, test)    // for CTEST2
+
+   This is not recommended but it is required on platforms that have no support
+   of linker sections.
+
+ * CTEST_DATA_IS_KEYWORD
+
+   Use '_data' instead of 'data'. Ugly workaround for MikroC.
+
+ * CTEST_COLOR_OK
+
+   Colorize 'OK' messages.

--- a/ctest.h
+++ b/ctest.h
@@ -627,6 +627,15 @@ static void color_print(const char* color, const char* text) {
         __CTEST_PRINTF("%s\n", text);
 }
 
+#ifdef CTEST_MORE_COLORS
+static void color_print_no_newline(const char* color, const char* text) {
+    if (color_output)
+        __CTEST_PRINTF("%s%s"ANSI_NORMAL, color, text);
+    else
+        __CTEST_PRINTF("%s", text);
+}
+#endif
+
 #ifdef __CTEST_APPLE
 static void *find_symbol(struct ctest *test, const char *fname)
 {
@@ -709,7 +718,16 @@ int ctest_main(int argc, const char *argv[])
             ctest_errorbuffer[0] = 0;
             ctest_errorsize = MSG_SIZE-1;
             ctest_errormsg = ctest_errorbuffer;
+#ifdef CTEST_MORE_COLORS
+            color_print_no_newline(ANSI_CYAN, "TEST");
+            __CTEST_PRINTF(" %d/%d ", index, total);
+            color_print_no_newline(ANSI_CYAN, test->ssname);
+            __CTEST_PRINTF(":");
+            color_print_no_newline(ANSI_MAGENTA, test->ttname);
+            __CTEST_PRINTF(" ");
+#else
             __CTEST_PRINTF("TEST %d/%d %s:%s ", index, total, test->ssname, test->ttname);
+#endif
             __CTEST_FLUSH();
             if (test->skip) {
                 color_print(ANSI_BYELLOW, "[SKIPPED]");
@@ -745,7 +763,7 @@ int ctest_main(int argc, const char *argv[])
                     error_code = 1;
                 }
                 if (error_code == 0) {
-#ifdef CTEST_COLOR_OK
+#if defined(CTEST_COLOR_OK) || defined(CTEST_MORE_COLORS)
                     color_print(ANSI_BGREEN, "[OK]");
 #else
                     __CTEST_PRINTF("[OK]\n");

--- a/ctest.h
+++ b/ctest.h
@@ -16,8 +16,168 @@
 #ifndef CTEST_H
 #define CTEST_H
 
+// for NULL
+#include <stddef.h>
+
+// detecting GCC
+#ifdef __GNUC__
+# define __CTEST_GCC
+#endif
+
+// detecting Apple
+#ifdef __APPLE__
+# define __CTEST_APPLE
+#endif
+
+// detecting MikroC compiler
+#if defined(__MIKROC_PRO_FOR_PIC32__) ||\
+    defined(__MIKROC_PRO_FOR_PIC__)   ||\
+    defined(__MIKROC_PRO_FOR_DSPIC__) ||\
+    defined(__MIKROC_PRO_FOR_AVR__)   ||\
+    defined(__MIKROC_PRO_FOR_ARM__)         // Only MikroC for ARM was really tested
+# define __CTEST_MIKROC
+#endif
+
+#ifdef __CTEST_MIKROC /** MikroC-specific **/
+
+/* Linker sections are not supported, so user should add tests manually.
+ */
+# ifndef CTEST_ADD_TESTS_MANUALLY
+#  define CTEST_ADD_TESTS_MANUALLY
+# endif
+
+/* Enabling workaround: 'data' is reserved keyword, we'll use _data instead.
+ */
+# ifndef CTEST_DATA_IS_KEYWORD
+#  define CTEST_DATA_IS_KEYWORD
+# endif
+
+/* Enabling workaround: function cast doesn't work in structure initializers
+ */
+# define __CTEST_NO_FUNC_CAST
+
+/* isatty() is not available.
+ */
+# define __CTEST_NO_TTY
+
+/* longjmp() is not available in MikroC, at least for ARM.
+ * It is probably available in MikroC for PIC, but that wasn't tested.
+ */
+# define __CTEST_NO_JMP
+
+/* gettimeofday() is not available.
+ */
+# define __CTEST_NO_TIME
+
+/* printf() and fflush() are not available().
+ */
+# define __CTEST_NO_PRINTF
+
+/* snprintf() is not available.
+ */
+# define __CTEST_NO_SNPRINTF
+
+/* `weak' attribute is not available.
+ */
+# define __CTEST_NO_WEAK
+
+#endif // __CTEST_MIKROC
+
+/** Check user macros **/
+
+#ifdef __CTEST_NO_TIME
+# ifndef CTEST_USER_TIME
+#  error It seems that gettimeofday() is not available, please define CTEST_USER_TIME() macro that will \
+         return current time in milliseconds
+# endif
+#endif // __CTEST_NO_TIME
+
+#ifdef __CTEST_NO_PRINTF
+# ifndef CTEST_USER_PRINTF
+#  error It seems that printf() is not available, please define CTEST_USER_PRINTF() macro that will \
+         emulate it
+# endif
+# ifndef CTEST_USER_FLUSH
+#  error It seems that fflush() is not available, please define CTEST_USER_FLUSH() macro that will \
+         emulate fflush(stdout)
+# endif
+#endif // __CTEST_NO_PRINTF
+
+/** Configure internal macros **/
+
+#ifdef CTEST_USER_TIME
+# define __CTEST_TIME CTEST_USER_TIME
+#else
+# define __CTEST_TIME ctest_getCurrentTime
+#endif // CTEST_USER_TIME
+
+#ifdef CTEST_USER_PRINTF
+# define __CTEST_PRINTF CTEST_USER_PRINTF
+#else
+# define __CTEST_PRINTF printf
+#endif // CTEST_USER_PRINTF
+
+#ifdef CTEST_USER_FLUSH
+# define __CTEST_FLUSH CTEST_USER_FLUSH
+#else
+# define __CTEST_FLUSH() fflush(stdout)
+#endif // CTEST_USER_FLUSH
+
+#ifdef CTEST_DATA_IS_KEYWORD
+# define __CTEST_DATA _data
+#else
+# define __CTEST_DATA data
+#endif // CTEST_DATA_IS_KEYWORD
+
+#ifdef __CTEST_NO_FUNC_CAST
+# define __CTEST_FUNC_CAST(_type, _name) (_name)
+#else
+# define __CTEST_FUNC_CAST(_type, _name) (_type)(_name)
+#endif // __CTEST_NO_CAST
+
+#ifdef __CTEST_NO_SNPRINTF
+/* If snprintf() is not available, use sprintf() and ignore buffer size.
+ * It is unsafe and can cause buffer overflow!
+ * Maybe there is some better solution..
+ */
+# define __CTEST_SNPRINTF(_buf, _len, ...) sprintf(_buf, __VA_ARGS__)
+#else
+# define __CTEST_SNPRINTF snprintf
+#endif // __CTEST_NO_SNPRINTF
+
+/* If longjmp() is not available, integer flag will be used instead of jmp_buf.
+ *
+ * __CTEST_SETJMP() will clear the flag and return zero, and __CTEST_LONGJMP()
+ * will set the flag to its argument. __CTEST_ERROR_CODE() will return that flag.
+ *
+ * If longjmp() is available, jmp_buf will be used as usual and __CTEST_ERROR_CODE()
+ * will always return zero.
+ *
+ * You can check both __CTEST_SETJMP() and __CTEST_ERROR_CODE() return value
+ * to detect error in a portable way.
+ */
+#ifdef __CTEST_NO_JMP
+# define __CTEST_JMPBUF                 int
+# define __CTEST_ERROR_CODE(_var)       (_var)
+# define __CTEST_SETJMP(_var)           (_var = 0)
+# define __CTEST_LONGJMP(_var, _err)    (_var = _err)
+#else // !__CTEST_NO_JMP
+# define __CTEST_JMPBUF                 jmp_buf
+# define __CTEST_ERROR_CODE(_var)       (0)
+# define __CTEST_SETJMP(_var)           setjmp(_var)
+# define __CTEST_LONGJMP(_var, _err)    longjmp(_var, _err)
+#endif // __CTEST_NO_JMP
+
+#ifdef __CTEST_NO_WEAK
+# define __CTEST_WEAK
+#else
+# define __CTEST_WEAK __attribute__ ((weak))
+#endif
+
+
 typedef void (*SetupFunc)(void*);
 typedef void (*TearDownFunc)(void*);
+typedef void (*RunWithDataFunc)(void*);
 
 struct ctest {
     const char* ssname;  // suite name
@@ -25,9 +185,11 @@ struct ctest {
     void (*run)();
     int skip;
 
-    void* data;
+    void* __CTEST_DATA;  // expands to '_data' if CTEST_DATA_IS_KEYWORD defined and to 'data' otherwise
     SetupFunc setup;
     TearDownFunc teardown;
+
+    struct ctest *next;
 
     unsigned int magic;
 };
@@ -36,37 +198,59 @@ struct ctest {
 #define __TNAME(sname, tname) __ctest_##sname##_##tname
 
 #define __CTEST_MAGIC (0xdeadbeef)
-#ifdef __APPLE__
-#define __Test_Section __attribute__ ((unused,section ("__DATA, .ctest")))
+
+#if defined(_WIN64) || defined(__amd64__)
+# define __CTEST_ALIGN 128
 #else
-#define __Test_Section __attribute__ ((unused,section (".ctest")))
+# define __CTEST_ALIGN 64
 #endif
 
+/* Since ctest struct can be aligned by compiler, we will align it explicitly and use
+ * following macros to access next and previous aligned pointers.
+ */
+#define __CTEST_NEXT(_test) (struct ctest *)((char *)(_test) + __CTEST_ALIGN)
+#define __CTEST_PREV(_test) (struct ctest *)((char *)(_test) - __CTEST_ALIGN)
+
+#ifdef CTEST_ADD_TESTS_MANUALLY
+# define __Test_Section
+#else // !CTEST_ADD_TESTS_MANUALLY
+# ifdef __CTEST_APPLE
+#  define __Test_Section __attribute__ ((unused,section ("__DATA, .ctest"))) __attribute__ ((aligned (__CTEST_ALIGN)))
+# else // !__CTEST_APPLE
+#  define __Test_Section __attribute__ ((unused,section (".ctest"))) __attribute__ ((aligned (__CTEST_ALIGN)))
+# endif // __CTEST_APPLE
+#endif // CTEST_ADD_TESTS_MANUALLY
+
+/* MikroC issues:
+ *    - named initializers are not supported;
+ *    - function cast in structure initializer doesn't work in some cases.
+ */
 #define __CTEST_STRUCT(sname, tname, _skip, __data, __setup, __teardown) \
     struct ctest __TNAME(sname, tname) __Test_Section = { \
-        .ssname=#sname, \
-        .ttname=#tname, \
-        .run = __FNAME(sname, tname), \
-        .skip = _skip, \
-        .data = __data, \
-        .setup = (SetupFunc)__setup,					\
-        .teardown = (TearDownFunc)__teardown,				\
-        .magic = __CTEST_MAGIC };
+        /* .ssname   = */ #sname, \
+        /* .ttname   = */ #tname, \
+        /* .run      = */ (void *)__FNAME(sname, tname), \
+        /* .skip     = */ _skip, \
+        /* .data     = */ __data, \
+        /* .setup    = */ __CTEST_FUNC_CAST(SetupFunc, __setup), \
+        /* .teardown = */ __CTEST_FUNC_CAST(TearDownFunc, __teardown), \
+        /* .next     = */ NULL, \
+        /* .magic    = */ __CTEST_MAGIC };
 
 #define CTEST_DATA(sname) struct sname##_data
 
 #define CTEST_SETUP(sname) \
-    void __attribute__ ((weak)) sname##_setup(struct sname##_data* data)
+    void __CTEST_WEAK sname##_setup(struct sname##_data* __CTEST_DATA)
 
 #define CTEST_TEARDOWN(sname) \
-    void __attribute__ ((weak)) sname##_teardown(struct sname##_data* data)
+    void __CTEST_WEAK sname##_teardown(struct sname##_data* __CTEST_DATA)
 
 #define __CTEST_INTERNAL(sname, tname, _skip) \
     void __FNAME(sname, tname)(); \
     __CTEST_STRUCT(sname, tname, _skip, NULL, NULL, NULL) \
     void __FNAME(sname, tname)()
 
-#ifdef __APPLE__
+#ifdef __CTEST_APPLE
 #define SETUP_FNAME(sname) NULL
 #define TEARDOWN_FNAME(sname) NULL
 #else
@@ -78,18 +262,57 @@ struct ctest {
     static struct sname##_data  __ctest_##sname##_data; \
     CTEST_SETUP(sname); \
     CTEST_TEARDOWN(sname); \
-    void __FNAME(sname, tname)(struct sname##_data* data); \
+    void __FNAME(sname, tname)(struct sname##_data* __CTEST_DATA); \
     __CTEST_STRUCT(sname, tname, _skip, &__ctest_##sname##_data, SETUP_FNAME(sname), TEARDOWN_FNAME(sname)) \
-    void __FNAME(sname, tname)(struct sname##_data* data)
+    void __FNAME(sname, tname)(struct sname##_data* __CTEST_DATA)
 
-
-void CTEST_LOG(char *fmt, ...);
 
 #define CTEST(sname, tname) __CTEST_INTERNAL(sname, tname, 0)
 #define CTEST_SKIP(sname, tname) __CTEST_INTERNAL(sname, tname, 1)
 
 #define CTEST2(sname, tname) __CTEST2_INTERNAL(sname, tname, 0)
 #define CTEST2_SKIP(sname, tname) __CTEST2_INTERNAL(sname, tname, 1)
+
+
+#ifdef CTEST_ADD_TESTS_MANUALLY
+
+void __ctest_addTest(struct ctest *);
+
+#define CTEST_ADD(sname, tname) do { \
+    extern struct ctest __TNAME(sname, tname); \
+    __ctest_addTest(&__TNAME(sname, tname)); \
+} while (0)
+
+/* MikroC needs this workaround becuase its compiler can remove setup, run and
+ * teardown functions.
+ *
+ * Possible workaround is to declare non-static variable that holds function
+ * address AND call that function explicitly (without pointer casts).
+ *
+ * This code is never executed, but it forces compiler not to remove that functions.
+ * Sorry.
+ */
+#ifdef __CTEST_MIKROC
+# define __CTEST_MIKROC_FUNCPTR_WORKAROUND(sname, tname) \
+    if (0) { \
+        void *setup = & SETUP_FNAME(sname); \
+        void *run = & __FNAME(sname, tname); \
+        void *teardown = & TEARDOWN_FNAME(sname); \
+        SETUP_FNAME(sname)(NULL); \
+        __FNAME(sname, tname)(NULL); \
+        TEARDOWN_FNAME(sname)(NULL); \
+    }
+#else
+# define __CTEST_MIKROC_FUNCPTR_WORKAROUND(sname, tname)
+#endif
+
+#define CTEST_ADD2(sname, tname) do { \
+    extern struct ctest __TNAME(sname, tname); \
+    __ctest_addTest(&__TNAME(sname, tname)); \
+    __CTEST_MIKROC_FUNCPTR_WORKAROUND(sname, tname) \
+} while (0)
+
+#endif // CTEST_ADD_TESTS_MANUALLY
 
 
 void assert_str(const char* exp, const char*  real, const char* caller, int line);
@@ -116,32 +339,11 @@ void assert_false(int real, const char* caller, int line);
 void assert_fail(const char* caller, int line);
 #define ASSERT_FAIL() assert_fail(__FILE__, __LINE__)
 
-#ifdef CTEST_MAIN
+extern size_t ctest_errorsize;
+extern char* ctest_errormsg;
 
-#include <setjmp.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <string.h>
-#include <sys/time.h>
-#include <unistd.h>
-#include <stdint.h>
-#include <stdlib.h>
-
-#ifdef __APPLE__
-#include <dlfcn.h>
-#endif
-
-//#define COLOR_OK
-
-static size_t ctest_errorsize;
-static char* ctest_errormsg;
-#define MSG_SIZE 4096
-static char ctest_errorbuffer[MSG_SIZE];
-static jmp_buf ctest_err;
-static int color_output = 1;
-static const char* suite_name;
-
-typedef int (*filter_func)(struct ctest*);
+void ctest_msg_start(const char* color, const char* title);
+void ctest_msg_end();
 
 #define ANSI_BLACK    "\033[0;30m"
 #define ANSI_RED      "\033[0;31m"
@@ -161,114 +363,211 @@ typedef int (*filter_func)(struct ctest*);
 #define ANSI_WHITE    "\033[01;37m"
 #define ANSI_NORMAL   "\033[0m"
 
-static CTEST(suite, test) { }
+/* Print log message.
+ * Using macro instead of function because vsnprintf() can be not available.
+ */
+#define CTEST_LOG(...)  do { \
+    int _size; \
+    ctest_msg_start(ANSI_BLUE, "LOG"); \
+    _size = __CTEST_SNPRINTF(ctest_errormsg, ctest_errorsize, __VA_ARGS__); \
+    ctest_errorsize -= _size; \
+    ctest_errormsg += _size; \
+    ctest_msg_end(); \
+} while (0)
 
-static void msg_start(const char* color, const char* title) {
+/* Print error message.
+ * Using macro instead of function because vsnprintf() can be not available.
+ */
+#define CTEST_ERR(_file, _line, ...) do { \
+    int _size; \
+    ctest_msg_start(ANSI_YELLOW, "ERR"); \
+    _size = __CTEST_SNPRINTF(ctest_errormsg, ctest_errorsize, "%s:%d ", _file, _line); \
+    ctest_errorsize -= _size; \
+    ctest_errormsg += _size; \
+    _size = __CTEST_SNPRINTF(ctest_errormsg, ctest_errorsize, __VA_ARGS__); \
+    ctest_errorsize -= _size; \
+    ctest_errormsg += _size; \
+    ctest_msg_end(); \
+} while (0)
+
+#ifndef CTEST_USER_PRINTF
+#include <stdio.h>
+#endif
+
+#ifdef CTEST_MAIN
+
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifndef __CTEST_NO_JMP
+#include <setjmp.h>
+#endif
+
+#ifndef __CTEST_NO_TTY
+#include <unistd.h>
+#endif
+
+#ifndef CTEST_USER_TIME
+#include <sys/time.h>
+#include <stdint.h>
+#endif
+
+#ifdef __CTEST_APPLE
+#include <dlfcn.h>
+#endif
+
+//#define CTEST_COLOR_OK
+
+size_t ctest_errorsize;
+char* ctest_errormsg;
+#define MSG_SIZE 4096
+static char ctest_errorbuffer[MSG_SIZE];
+static __CTEST_JMPBUF ctest_err;
+static int color_output = 1;
+static const char* suite_name;
+
+typedef int (*filter_func)(struct ctest*);
+
+#ifndef __CTEST_MIKROC
+// MikroC linker workaround
+static
+#endif
+CTEST(suite, test) { }
+
+/* First element of test list.
+ */
+static struct ctest *__ctest_head = &__TNAME(suite, test);
+
+#ifdef CTEST_ADD_TESTS_MANUALLY
+
+/* Last element of test list.
+ */
+static struct ctest *__ctest_tail = &__TNAME(suite, test);
+
+/* Add test to linked list manually.
+ */
+void __ctest_addTest(struct ctest *test)
+{
+    __ctest_tail->next = test;
+    __ctest_tail = test;
+}
+
+#else // !CTEST_ADD_TESTS_MANUALLY
+
+/* Add all tests to linked list automatically.
+ */
+static void __ctest_linkTests()
+{
+    struct ctest *test;
+    struct ctest* ctest_begin = &__TNAME(suite, test);
+    struct ctest* ctest_end = &__TNAME(suite, test);
+
+    // find begin and end of section by comparing magics
+    while (1) {
+        struct ctest* t = __CTEST_PREV(ctest_begin);
+        if (t->magic != __CTEST_MAGIC) break;
+        ctest_begin = t;
+    }
+    while (1) {
+        struct ctest* t = __CTEST_NEXT(ctest_end);
+        if (t->magic != __CTEST_MAGIC) break;
+        ctest_end = t;
+    }
+    ctest_end = __CTEST_NEXT(ctest_end); // end after last one
+
+    for (test = ctest_begin; test != ctest_end; test = __CTEST_NEXT(test)) {
+        struct ctest *next = __CTEST_NEXT(test);
+        if (next == ctest_end)
+            next = NULL;
+
+        test->next = next;
+    }
+
+    __ctest_head = ctest_begin;
+}
+
+#endif // CTEST_ADD_TESTS_MANUALLY
+
+
+void ctest_msg_start(const char* color, const char* title) {
     int size;
     if (color_output) {
-        size = snprintf(ctest_errormsg, ctest_errorsize, "%s", color);
+        size = __CTEST_SNPRINTF(ctest_errormsg, ctest_errorsize, "%s", color);
         ctest_errorsize -= size;
         ctest_errormsg += size;
     }
-    size = snprintf(ctest_errormsg, ctest_errorsize, "  %s: ", title);
+    size = __CTEST_SNPRINTF(ctest_errormsg, ctest_errorsize, "  %s: ", title);
     ctest_errorsize -= size;
     ctest_errormsg += size;
 }
 
-static void msg_end() {
+void ctest_msg_end() {
     int size;
     if (color_output) {
-        size = snprintf(ctest_errormsg, ctest_errorsize, ANSI_NORMAL);
+        size = __CTEST_SNPRINTF(ctest_errormsg, ctest_errorsize, ANSI_NORMAL);
         ctest_errorsize -= size;
         ctest_errormsg += size;
     }
-    size = snprintf(ctest_errormsg, ctest_errorsize, "\n");
+    size = __CTEST_SNPRINTF(ctest_errormsg, ctest_errorsize, "\n");
     ctest_errorsize -= size;
     ctest_errormsg += size;
-}
-
-void CTEST_LOG(char *fmt, ...)
-{
-    va_list argp;
-    msg_start(ANSI_BLUE, "LOG");
-
-    va_start(argp, fmt);
-    int size = vsnprintf(ctest_errormsg, ctest_errorsize, fmt, argp);
-    ctest_errorsize -= size;
-    ctest_errormsg += size;
-    va_end(argp);
-
-    msg_end();
-}
-
-void CTEST_ERR(char *fmt, ...)
-{
-    va_list argp;
-    msg_start(ANSI_YELLOW, "ERR");
-
-    va_start(argp, fmt);
-    int size = vsnprintf(ctest_errormsg, ctest_errorsize, fmt, argp);
-    ctest_errorsize -= size;
-    ctest_errormsg += size;
-    va_end(argp);
-
-    msg_end();
 }
 
 void assert_str(const char* exp, const char*  real, const char* caller, int line) {
     if ((exp == NULL && real != NULL) ||
         (exp != NULL && real == NULL) ||
         (exp && real && strcmp(exp, real) != 0)) {
-        CTEST_ERR("%s:%d  expected '%s', got '%s'", caller, line, exp, real);
-        longjmp(ctest_err, 1);
+        CTEST_ERR(caller, line, "expected '%s', got '%s'", exp, real);
+        __CTEST_LONGJMP(ctest_err, 1);
     }
 }
 
 void assert_equal(long exp, long real, const char* caller, int line) {
     if (exp != real) {
-        CTEST_ERR("%s:%d  expected %ld, got %ld", caller, line, exp, real);
-        longjmp(ctest_err, 1);
+        CTEST_ERR(caller, line, "expected %ld, got %ld", exp, real);
+        __CTEST_LONGJMP(ctest_err, 1);
     }
 }
 
 void assert_not_equal(long exp, long real, const char* caller, int line) {
     if ((exp) == (real)) {
-        CTEST_ERR("%s:%d  should not be %ld", caller, line, real);
-        longjmp(ctest_err, 1);
+        CTEST_ERR(caller, line, "should not be %ld", real);
+        __CTEST_LONGJMP(ctest_err, 1);
     }
 }
 
 void assert_null(void* real, const char* caller, int line) {
     if ((real) != NULL) {
-        CTEST_ERR("%s:%d  should be NULL", caller, line);
-        longjmp(ctest_err, 1);
+        CTEST_ERR(caller, line, "should be NULL");
+        __CTEST_LONGJMP(ctest_err, 1);
     }
 }
 
 void assert_not_null(void* real, const char* caller, int line) {
     if (real == NULL) {
-        CTEST_ERR("%s:%d  should not be NULL", caller, line);
-        longjmp(ctest_err, 1);
+        CTEST_ERR(caller, line, "should not be NULL");
+        __CTEST_LONGJMP(ctest_err, 1);
     }
 }
 
 void assert_true(int real, const char* caller, int line) {
     if ((real) == 0) {
-        CTEST_ERR("%s:%d  should be true", caller, line);
-        longjmp(ctest_err, 1);
+        CTEST_ERR(caller, line, "should be true");
+        __CTEST_LONGJMP(ctest_err, 1);
     }
 }
 
 void assert_false(int real, const char* caller, int line) {
     if ((real) != 0) {
-        CTEST_ERR("%s:%d  should be false", caller, line);
-        longjmp(ctest_err, 1);
+        CTEST_ERR(caller, line, "should be false");
+        __CTEST_LONGJMP(ctest_err, 1);
     }
 }
 
 void assert_fail(const char* caller, int line) {
-    CTEST_ERR("%s:%d  shouldn't come here", caller, line);
-    longjmp(ctest_err, 1);
+    CTEST_ERR(caller, line, "shouldn't come here");
+    __CTEST_LONGJMP(ctest_err, 1);
 }
 
 
@@ -276,11 +575,12 @@ static int suite_all(struct ctest* t) {
     return 1;
 }
 
-static int suite_filter(struct ctest* t) { 
+static int suite_filter(struct ctest* t) {
     return strncmp(suite_name, t->ssname, strlen(suite_name)) == 0;
 }
 
-static uint64_t getCurrentTime() {
+#ifndef CTEST_USER_TIME
+static uint64_t ctest_getCurrentTime() {
     struct timeval now;
     gettimeofday(&now, NULL);
     uint64_t now64 = now.tv_sec;
@@ -288,21 +588,22 @@ static uint64_t getCurrentTime() {
     now64 += (now.tv_usec);
     return now64;
 }
+#endif // CTEST_USER_TIME
 
 static void color_print(const char* color, const char* text) {
     if (color_output)
-        printf("%s%s"ANSI_NORMAL"\n", color, text);
+        __CTEST_PRINTF("%s%s"ANSI_NORMAL"\n", color, text);
     else
-        printf("%s\n", text);
+        __CTEST_PRINTF("%s\n", text);
 }
 
-#ifdef __APPLE__
+#ifdef __CTEST_APPLE
 static void *find_symbol(struct ctest *test, const char *fname)
 {
     size_t len = strlen(test->ssname) + 1 + strlen(fname);
     char *symbol_name = (char *) malloc(len + 1);
     memset(symbol_name, 0, len + 1);
-    snprintf(symbol_name, len + 1, "%s_%s", test->ssname, fname);
+    __CTEST_SNPRINTF(symbol_name, len + 1, "%s_%s", test->ssname, fname);
 
     //fprintf(stderr, ">>>> dlsym: loading %s\n", symbol_name);
     void *symbol = dlsym(RTLD_DEFAULT, symbol_name);
@@ -310,65 +611,72 @@ static void *find_symbol(struct ctest *test, const char *fname)
         //fprintf(stderr, ">>>> ERROR: %s\n", dlerror());
     }
     // returns NULL on error
-    
+
     free(symbol_name);
     return symbol;
 }
 #endif
 
+
 int ctest_main(int argc, const char *argv[])
 {
-    static int total = 0;
-    static int num_ok = 0;
-    static int num_fail = 0;
-    static int num_skip = 0;
-    static int index = 1;
+    static int total;
+    static int num_ok;
+    static int num_fail;
+    static int num_skip;
+    static int index;
     static filter_func filter = suite_all;
+
+    unsigned long long t1;
+    unsigned long long t2;
+
+    struct ctest* test;
+    const char* color;
+    static char results[80];
+
+    // Reinitialize static variables to allow calling ctest_main() more than once.
+    total = 0;
+    num_ok = 0;
+    num_fail = 0;
+    num_skip = 0;
+    index = 1;
+
+#ifndef __CTEST_NO_TTY
+    color_output = isatty(1);
+#endif
 
     if (argc == 2) {
         suite_name = argv[1];
         filter = suite_filter;
     }
 
-    color_output = isatty(1);
-    uint64_t t1 = getCurrentTime();
+    t1 = __CTEST_TIME();
 
-    struct ctest* ctest_begin = &__TNAME(suite, test);
-    struct ctest* ctest_end = &__TNAME(suite, test);
-    // find begin and end of section by comparing magics
-    while (1) {
-        struct ctest* t = ctest_begin-1;
-        if (t->magic != __CTEST_MAGIC) break;
-        ctest_begin--;
-    }
-    while (1) {
-        struct ctest* t = ctest_end+1;
-        if (t->magic != __CTEST_MAGIC) break;
-        ctest_end++;
-    }
-    ctest_end++;    // end after last one
+#ifndef CTEST_ADD_TESTS_MANUALLY
+    __ctest_linkTests();
+#endif
 
-    static struct ctest* test;
-    for (test = ctest_begin; test != ctest_end; test++) {
-        if (test == &__ctest_suite_test) continue;
+    for (test = __ctest_head; test != NULL; test = test->next) {
+        if (test == &__TNAME(suite, test)) continue;
         if (filter(test)) total++;
     }
 
-    for (test = ctest_begin; test != ctest_end; test++) {
-        if (test == &__ctest_suite_test) continue;
+    for (test = __ctest_head; test != NULL; test = test->next) {
+        if (test == &__TNAME(suite, test)) continue;
         if (filter(test)) {
             ctest_errorbuffer[0] = 0;
             ctest_errorsize = MSG_SIZE-1;
             ctest_errormsg = ctest_errorbuffer;
-            printf("TEST %d/%d %s:%s ", index, total, test->ssname, test->ttname);
-            fflush(stdout);
+            __CTEST_PRINTF("TEST %d/%d %s:%s ", index, total, test->ssname, test->ttname);
+            __CTEST_FLUSH();
             if (test->skip) {
                 color_print(ANSI_BYELLOW, "[SKIPPED]");
                 num_skip++;
             } else {
-                int result = setjmp(ctest_err);
+                int error_code;
+                int result = __CTEST_SETJMP(ctest_err);
                 if (result == 0) {
-#ifdef __APPLE__
+#ifdef __CTEST_APPLE
                     if (!test->setup) {
                         test->setup = find_symbol(test, "setup");
                     }
@@ -377,38 +685,49 @@ int ctest_main(int argc, const char *argv[])
                     }
 #endif
 
-                    if (test->setup) test->setup(test->data);
-                    if (test->data) 
-                      test->run(test->data);
-                    else 
+                    if (test->setup) test->setup(test->__CTEST_DATA);
+                    if (test->__CTEST_DATA)
+                      ((RunWithDataFunc)test->run)(test->__CTEST_DATA);
+                    else
                       test->run();
-                    if (test->teardown) test->teardown(test->data);
-                    // if we got here it's ok
-#ifdef COLOR_OK
+                    if (test->teardown) test->teardown(test->__CTEST_DATA);
+                    /* If longjmp() is available and we got here, it's ok and __CTEST_ERROR_CODE()
+                     * will also return zero.
+                     *
+                     * If longjmp() is not available, __CTEST_ERROR_CODE() will return non-zero
+                     * if error was detected.
+                     */
+                    error_code = __CTEST_ERROR_CODE(ctest_err);
+                } else {
+                    // If we got here, longjmp() is available and was called, so error occured.
+                    error_code = 1;
+                }
+                if (error_code == 0) {
+#ifdef CTEST_COLOR_OK
                     color_print(ANSI_BGREEN, "[OK]");
 #else
-                    printf("[OK]\n");
+                    __CTEST_PRINTF("[OK]\n");
 #endif
                     num_ok++;
                 } else {
                     color_print(ANSI_BRED, "[FAIL]");
                     num_fail++;
                 }
-                if (ctest_errorsize != MSG_SIZE-1) printf("%s", ctest_errorbuffer);
+                if (ctest_errorsize != MSG_SIZE-1) __CTEST_PRINTF("%s", ctest_errorbuffer);
             }
             index++;
         }
     }
-    uint64_t t2 = getCurrentTime();
+    t2 = __CTEST_TIME();
 
-    const char* color = (num_fail) ? ANSI_BRED : ANSI_GREEN;
-    char results[80];
-    sprintf(results, "RESULTS: %d tests (%d ok, %d failed, %d skipped) ran in %lld ms", total, num_ok, num_fail, num_skip, (t2 - t1)/1000);
+    color = (num_fail) ? ANSI_BRED : ANSI_GREEN;
+    __CTEST_SNPRINTF(results, sizeof(results),
+                     "RESULTS: %d tests (%d ok, %d failed, %d skipped) ran in %lld ms",
+                         total, num_ok, num_fail, num_skip, (t2 - t1)/1000);
     color_print(color, results);
     return num_fail;
 }
 
-#endif
+#endif // CTEST_MAIN
 
-#endif
-
+#endif // CTEST_H


### PR DESCRIPTION
Hello! Thanks for sharing your code.

This request includes a port to MikroC compiler (for ARM).

In one hand, this patch includes macros that hopefully make it easier to port ctest to new platforms. I think ctest is a good choice for embedded: it's quite easy to port it to because it is only one header; and it still has useful features.

In other hand, this patch includes several ugly workarounds and #ifdefs related to MikroC issues.

Please see modified version of README and commit message for details.

Two last commits just add some minor features.

The main reason I'm publishing these changes is that I didn't find any test harness available for MikroC.