### PR TITLE
added support for comparing doubles

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ CTEST(suite, test1) {
 CTEST(suite, test2) {
     ASSERT_EQUAL(1, 2);
 }
+
+CTEST(suite, test_dbl) {
+    ASSERT_DBL_NEAR(0.0001, 0.00011);
+    ASSERT_DBL_NEAR_TOL(0.0001, 0.00011, 1e-5);
+}
 ```
 
 NO further typing is needed! ctest does the rest.

--- a/ctest.h
+++ b/ctest.h
@@ -123,6 +123,14 @@ void assert_false(int real, const char* caller, int line);
 void assert_fail(const char* caller, int line);
 #define ASSERT_FAIL() assert_fail(__FILE__, __LINE__)
 
+void assert_dbl_near(double exp, double real, double tol, const char* caller, int line);
+#define ASSERT_DBL_NEAR(exp, real) assert_dbl_near(exp, real, 1e-4, __FILE__, __LINE__)
+#define ASSERT_DBL_NEAR_TOL(exp, real, tol) assert_dbl_near(exp, real, tol, __FILE__, __LINE__)
+
+void assert_dbl_far(double exp, double real, double tol, const char* caller, int line);
+#define ASSERT_DBL_FAR(exp, real) assert_dbl_far(exp, real, 1e-4, __FILE__, __LINE__)
+#define ASSERT_DBL_FAR_TOL(exp, real, tol) assert_dbl_far(exp, real, tol, __FILE__, __LINE__)
+
 #ifdef CTEST_MAIN
 
 #include <setjmp.h>
@@ -256,6 +264,30 @@ void assert_equal(long exp, long real, const char* caller, int line) {
 void assert_not_equal(long exp, long real, const char* caller, int line) {
     if ((exp) == (real)) {
         CTEST_ERR("%s:%d  should not be %ld", caller, line, real);
+    }
+}
+
+void assert_dbl_near(double exp, double real, double tol, const char* caller, int line) {
+    double diff = exp - real;
+    double absdiff = diff;
+    /* avoid using fabs and linking with a math lib */
+    if(diff < 0) {
+      absdiff *= -1;
+    }
+    if (absdiff > tol) {
+        CTEST_ERR("%s:%d  expected %0.3e, got %0.3e (diff %0.3e, tol %0.3e)", caller, line, exp, real, diff, tol);
+    }
+}
+
+void assert_dbl_far(double exp, double real, double tol, const char* caller, int line) {
+    double diff = exp - real;
+    double absdiff = diff;
+    /* avoid using fabs and linking with a math lib */
+    if(diff < 0) {
+      absdiff *= -1;
+    }
+    if (absdiff <= tol) {
+        CTEST_ERR("%s:%d  expected %0.3e, got %0.3e (diff %0.3e, tol %0.3e)", caller, line, exp, real, diff, tol);
     }
 }
 

--- a/mytests.c
+++ b/mytests.c
@@ -169,3 +169,19 @@ CTEST(ctest, test_ctest_err) {
     CTEST_ERR("error log");
 }
 
+CTEST(ctest, test_dbl_near) {
+    double a = 0.000111;
+    ASSERT_DBL_NEAR(0.0001, a);
+}
+
+CTEST(ctest, test_dbl_near_tol) {
+    double a = 0.000111;
+    ASSERT_DBL_NEAR_TOL(0.0001, a, 1e-5); /* will fail */
+}
+
+CTEST(ctest, test_dbl_far) {
+    double a = 1.1;
+    ASSERT_DBL_FAR(1., a);
+    ASSERT_DBL_FAR_TOL(1., a, 0.01);
+}
+


### PR DESCRIPTION
This adds support for comparing double-precision floating point numbers. I explicitly avoided 'equality' because that is usually not the correct behavior.

Comparing doubles is accomplished with `ASSERT_DBL_NEAR(exp, actual)`, which asserts that the absolute value of the two values is less than 1e-4. `ASSERT_DBL_FAR` ensures that the difference is at least 1e-4.

Both NEAR and FAR include `_TOL` alternatives, in which the user can specify a tolerance other than 1e-4.

It may also be worthwhile to consider adding `ASSERT_FLT_` tests for testing precision issues.