### PR TITLE
maintain a definition (USE_COLORS) for the use of colors

### DIFF
--- a/ctest.h
+++ b/ctest.h
@@ -147,22 +147,14 @@ void assert_dbl_far(double exp, double real, double tol, const char* caller, int
 #include <dlfcn.h>
 #endif
 
-#ifdef WIN32
-#undef USE_COLORS
-#endif
-
-#ifdef USE_COLORS
-static int color_output = 1;
 //#define COLOR_OK
-#else
-static int color_output = 0;
-#endif
 
 static size_t ctest_errorsize;
 static char* ctest_errormsg;
 #define MSG_SIZE 4096
 static char ctest_errorbuffer[MSG_SIZE];
 static jmp_buf ctest_err;
+static int color_output = 1;
 static const char* suite_name;
 
 typedef int (*filter_func)(struct ctest*);
@@ -405,8 +397,11 @@ int ctest_main(int argc, const char *argv[])
         suite_name = argv[1];
         filter = suite_filter;
     }
-
+#ifdef USE_COLORS
     color_output = isatty(1);
+#else
+    color_output = 0;
+#endif
     uint64_t t1 = getCurrentTime();
 
     struct ctest* ctest_begin = &__TNAME(suite, test);

--- a/ctest.h
+++ b/ctest.h
@@ -397,7 +397,7 @@ int ctest_main(int argc, const char *argv[])
         suite_name = argv[1];
         filter = suite_filter;
     }
-#ifdef USE_COLORS
+#ifdef CTEST_USE_COLORS
     color_output = isatty(1);
 #else
     color_output = 0;

--- a/ctest.h
+++ b/ctest.h
@@ -147,14 +147,22 @@ void assert_dbl_far(double exp, double real, double tol, const char* caller, int
 #include <dlfcn.h>
 #endif
 
+#ifdef WIN32
+#undef USE_COLORS
+#endif
+
+#ifdef USE_COLORS
+static int color_output = 1;
 //#define COLOR_OK
+#else
+static int color_output = 0;
+#endif
 
 static size_t ctest_errorsize;
 static char* ctest_errormsg;
 #define MSG_SIZE 4096
 static char ctest_errorbuffer[MSG_SIZE];
 static jmp_buf ctest_err;
-static int color_output = 1;
 static const char* suite_name;
 
 typedef int (*filter_func)(struct ctest*);
@@ -447,9 +455,9 @@ int ctest_main(int argc, const char *argv[])
 
                     if (test->setup) test->setup(test->data);
                     if (test->data)
-                      test->run(test->data);
+                        test->run(test->data);
                     else
-                      test->run();
+                        test->run();
                     if (test->teardown) test->teardown(test->data);
                     // if we got here it's ok
 #ifdef COLOR_OK

--- a/main.c
+++ b/main.c
@@ -3,7 +3,7 @@
 #define CTEST_MAIN
 // uncomment line below to get nicer logging on segfaults
 #define CTEST_SEGFAULT
-#define USE_COLORS
+#define CTEST_USE_COLORS
 #include "ctest.h"
 
 int main(int argc, const char *argv[])

--- a/main.c
+++ b/main.c
@@ -3,6 +3,7 @@
 #define CTEST_MAIN
 // uncomment line below to get nicer logging on segfaults
 #define CTEST_SEGFAULT
+#define USE_COLORS
 #include "ctest.h"
 
 int main(int argc, const char *argv[])


### PR DESCRIPTION
Hi,

In my project I specify the use of colors during the build process. To this end I've introduced a definition (USE_COLORS) that allows to turn on or off the use of colors at compile time..

Thanks, Chris.