### PR TITLE
Possible integer truncations

### DIFF
--- a/ctest.h
+++ b/ctest.h
@@ -116,11 +116,17 @@ void assert_data(const unsigned char* exp, size_t expsize,
 #define ASSERT_DATA(exp, expsize, real, realsize) \
     assert_data(exp, expsize, real, realsize, __FILE__, __LINE__)
 
-void assert_equal(long exp, long real, const char* caller, int line);
+void assert_equal(ssize_t exp, ssize_t real, const char* caller, int line);
 #define ASSERT_EQUAL(exp, real) assert_equal(exp, real, __FILE__, __LINE__)
 
-void assert_not_equal(long exp, long real, const char* caller, int line);
+void assert_equal_u(size_t exp, size_t real, const char* caller, int line);
+#define ASSERT_EQUAL_U(exp, real) assert_equal_u(exp, real, __FILE__, __LINE__)
+
+void assert_not_equal(ssize_t exp, ssize_t real, const char* caller, int line);
 #define ASSERT_NOT_EQUAL(exp, real) assert_not_equal(exp, real, __FILE__, __LINE__)
+
+void assert_not_equal_u(size_t exp, size_t real, const char* caller, int line);
+#define ASSERT_NOT_EQUAL_U(exp, real) assert_not_equal_u(exp, real, __FILE__, __LINE__)
 
 void assert_null(void* real, const char* caller, int line);
 #define ASSERT_NULL(real) assert_null((void*)real, __FILE__, __LINE__)
@@ -276,15 +282,27 @@ void assert_data(const unsigned char* exp, size_t expsize,
     }
 }
 
-void assert_equal(long exp, long real, const char* caller, int line) {
+void assert_equal(ssize_t exp, ssize_t real, const char* caller, int line) {
     if (exp != real) {
-        CTEST_ERR("%s:%d  expected %ld, got %ld", caller, line, exp, real);
+        CTEST_ERR("%s:%d  expected %lld, got %lld", caller, line, (long long) exp, (long long) real);
     }
 }
 
-void assert_not_equal(long exp, long real, const char* caller, int line) {
+void assert_equal_u(size_t exp, size_t real, const char* caller, int line) {
+    if (exp != real) {
+        CTEST_ERR("%s:%d  expected %llu, got %llu", caller, line, (unsigned long long) exp, (unsigned long long) real);
+    }
+}
+
+void assert_not_equal(ssize_t exp, ssize_t real, const char* caller, int line) {
     if ((exp) == (real)) {
-        CTEST_ERR("%s:%d  should not be %ld", caller, line, real);
+        CTEST_ERR("%s:%d  should not be %lld", caller, (long long) line, (long long) real);
+    }
+}
+
+void assert_not_equal_u(size_t exp, size_t real, const char* caller, int line) {
+    if ((exp) == (real)) {
+        CTEST_ERR("%s:%d  should not be %llu", caller, (unsigned long long) line, (unsigned long long) real);
     }
 }
 

--- a/ctest.h
+++ b/ctest.h
@@ -28,6 +28,8 @@
 #define WEAK
 #endif
 
+#include <stdio.h>
+
 typedef void (*SetupFunc)(void*);
 typedef void (*TearDownFunc)(void*);
 
@@ -108,8 +110,8 @@ void CTEST_ERR(char *fmt, ...);  // doesn't return
 void assert_str(const char* exp, const char* real, const char* caller, int line);
 #define ASSERT_STR(exp, real) assert_str(exp, real, __FILE__, __LINE__)
 
-void assert_data(const unsigned char* exp, int expsize,
-                 const unsigned char* real, int realsize,
+void assert_data(const unsigned char* exp, size_t expsize,
+                 const unsigned char* real, size_t realsize,
                  const char* caller, int line);
 #define ASSERT_DATA(exp, expsize, real, realsize) \
     assert_data(exp, expsize, real, realsize, __FILE__, __LINE__)
@@ -259,17 +261,17 @@ void assert_str(const char* exp, const char*  real, const char* caller, int line
     }
 }
 
-void assert_data(const unsigned char* exp, int expsize,
-                 const unsigned char* real, int realsize,
+void assert_data(const unsigned char* exp, size_t expsize,
+                 const unsigned char* real, size_t realsize,
                  const char* caller, int line) {
-    int i;
+    size_t i;
     if (expsize != realsize) {
         CTEST_ERR("%s:%d  expected %d bytes, got %d", caller, line, expsize, realsize);
     }
     for (i=0; i<expsize; i++) {
         if (exp[i] != real[i]) {
-            CTEST_ERR("%s:%d expected 0x%02x at offset %d got 0x%02x",
-                caller, line, exp[i], i, real[i]);
+            CTEST_ERR("%s:%d expected 0x%02x at offset %llu got 0x%02x",
+                caller, line, exp[i], (unsigned long long) i, real[i]);
         }
     }
 }

--- a/mytests.c
+++ b/mytests.c
@@ -160,9 +160,9 @@ CTEST(ctest, test_string_diff_ptrs) {
 }
 
 CTEST(ctest, test_large_numbers) {
-    long exp = 7200000000;
-    ASSERT_EQUAL(exp, 7200000000);
-    ASSERT_NOT_EQUAL(exp, 1200000000);
+    unsigned long exp = 4200000000u;
+    ASSERT_EQUAL_U(exp, 4200000000u);
+    ASSERT_NOT_EQUAL_U(exp, 1200000000u);
 }
 
 CTEST(ctest, test_ctest_err) {
@@ -184,4 +184,3 @@ CTEST(ctest, test_dbl_far) {
     ASSERT_DBL_FAR(1., a);
     ASSERT_DBL_FAR_TOL(1., a, 0.01);
 }
-


### PR DESCRIPTION
Hi,

I've got another one :sweat_smile: This one consists of two different issues:
1) For comparing memory int might not be large enough to cover the full range (0634f5d)
2) Using long for ASSERT_EQUAL and ASSERT_NOT_EQUAL might be problematic for comparing values of size_t for instance. Furthermore I introduced different functions for signed and unsigned values (aa76812)

In both cases, I had to explicitly cast size_t and ssize_t values for formatting the output instead of using "%zu" and "%zd" as ctest doesn't seem to make use of C99 otherwise.

Cheers, Chris.