### PR TITLE
explicitly cast the output of find_symbol function

### DIFF
--- a/ctest.h
+++ b/ctest.h
@@ -481,10 +481,10 @@ int ctest_main(int argc, const char *argv[])
                 if (result == 0) {
 #ifdef __APPLE__
                     if (!test->setup) {
-                        test->setup = find_symbol(test, "setup");
+                        test->setup = (SetupFunc) find_symbol(test, "setup");
                     }
                     if (!test->teardown) {
-                        test->teardown = find_symbol(test, "teardown");
+                        test->teardown = (SetupFunc) find_symbol(test, "teardown");
                     }
 #endif
 


### PR DESCRIPTION
Hi,
when compiling ctest using -Wpedantic on OS X clang complains about the implicit conversion from void pointer to the SetupFunc function pointer. An explicit cast fixes this.

All the best, Chris.