### PR TITLE
Eliminate warnings reported by Clang with `-Weverything`

### DIFF
--- a/ctest.h
+++ b/ctest.h
@@ -72,15 +72,17 @@ struct ctest {
 #define CTEST_DATA(sname) struct CTEST_IMPL_NAME(sname##_data)
 
 #define CTEST_SETUP(sname) \
+    void CTEST_IMPL_WEAK CTEST_IMPL_NAME(sname##_setup)(struct CTEST_IMPL_NAME(sname##_data)* data); \
     void CTEST_IMPL_WEAK CTEST_IMPL_NAME(sname##_setup)(struct CTEST_IMPL_NAME(sname##_data)* data)
 
 #define CTEST_TEARDOWN(sname) \
+    void CTEST_IMPL_WEAK CTEST_IMPL_NAME(sname##_teardown)(struct CTEST_IMPL_NAME(sname##_data)* data); \
     void CTEST_IMPL_WEAK CTEST_IMPL_NAME(sname##_teardown)(struct CTEST_IMPL_NAME(sname##_data)* data)
 
 #define CTEST_IMPL_CTEST(sname, tname, tskip) \
-    void CTEST_IMPL_FNAME(sname, tname)(); \
+    static void CTEST_IMPL_FNAME(sname, tname)(void); \
     CTEST_IMPL_STRUCT(sname, tname, tskip, NULL, NULL, NULL); \
-    void CTEST_IMPL_FNAME(sname, tname)()
+    static void CTEST_IMPL_FNAME(sname, tname)(void)
 
 #ifdef __APPLE__
 #define CTEST_IMPL_SETUP_FNAME(sname) NULL
@@ -94,9 +96,9 @@ struct ctest {
     static struct CTEST_IMPL_NAME(sname##_data) CTEST_IMPL_NAME(sname##_data); \
     CTEST_SETUP(sname); \
     CTEST_TEARDOWN(sname); \
-    void CTEST_IMPL_FNAME(sname, tname)(struct CTEST_IMPL_NAME(sname##_data)* data); \
+    static void CTEST_IMPL_FNAME(sname, tname)(struct CTEST_IMPL_NAME(sname##_data)* data); \
     CTEST_IMPL_STRUCT(sname, tname, tskip, &CTEST_IMPL_NAME(sname##_data), CTEST_IMPL_SETUP_FNAME(sname), CTEST_IMPL_TEARDOWN_FNAME(sname)); \
-    void CTEST_IMPL_FNAME(sname, tname)(struct CTEST_IMPL_NAME(sname##_data)* data)
+    static void CTEST_IMPL_FNAME(sname, tname)(struct CTEST_IMPL_NAME(sname##_data)* data)
 
 
 void CTEST_LOG(const char* fmt, ...);
@@ -199,7 +201,7 @@ typedef int (*ctest_filter_func)(struct ctest*);
 #define ANSI_WHITE    "\033[01;37m"
 #define ANSI_NORMAL   "\033[0m"
 
-static CTEST(suite, test) { }
+CTEST(suite, test) { }
 
 inline static void vprint_errormsg(const char* const fmt, va_list ap) {
 	// (v)snprintf returns the number that would have been written
@@ -428,6 +430,8 @@ static void sighandler(int signum)
     kill(getpid(), signum);
 }
 #endif
+
+int ctest_main(int argc, const char *argv[]);
 
 int ctest_main(int argc, const char *argv[])
 {

--- a/ctest.h
+++ b/ctest.h
@@ -260,6 +260,11 @@ void CTEST_LOG(const char* fmt, ...)
     msg_end();
 }
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-noreturn"
+#endif
+
 void CTEST_ERR(const char* fmt, ...)
 {
     va_list argp;
@@ -272,6 +277,10 @@ void CTEST_ERR(const char* fmt, ...)
     msg_end();
     longjmp(ctest_err, 1);
 }
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 void assert_str(const char* exp, const char*  real, const char* caller, int line) {
     if ((exp == NULL && real != NULL) ||

--- a/ctest.h
+++ b/ctest.h
@@ -28,6 +28,12 @@
 #define CTEST_IMPL_WEAK
 #endif
 
+#ifdef __GNUC__
+#define CTEST_IMPL_FORMAT_PRINTF(a, b) __attribute__ ((format(printf, a, b)))
+#else
+#define CTEST_IMPL_FORMAT_PRINTF(a, b)
+#endif
+
 #include <inttypes.h> /* intmax_t, uintmax_t, PRI* */
 #include <stddef.h> /* size_t */
 
@@ -101,8 +107,8 @@ struct ctest {
     static void CTEST_IMPL_FNAME(sname, tname)(struct CTEST_IMPL_NAME(sname##_data)* data)
 
 
-void CTEST_LOG(const char* fmt, ...);
-void CTEST_ERR(const char* fmt, ...);  // doesn't return
+void CTEST_LOG(const char* fmt, ...) CTEST_IMPL_FORMAT_PRINTF(1, 2);
+void CTEST_ERR(const char* fmt, ...) CTEST_IMPL_FORMAT_PRINTF(1, 2);  // doesn't return
 
 #define CTEST(sname, tname) CTEST_IMPL_CTEST(sname, tname, 0)
 #define CTEST_SKIP(sname, tname) CTEST_IMPL_CTEST(sname, tname, 1)
@@ -202,6 +208,9 @@ typedef int (*ctest_filter_func)(struct ctest*);
 #define ANSI_NORMAL   "\033[0m"
 
 CTEST(suite, test) { }
+
+inline static void vprint_errormsg(const char* const fmt, va_list ap) CTEST_IMPL_FORMAT_PRINTF(1, 0);
+inline static void print_errormsg(const char* const fmt, ...) CTEST_IMPL_FORMAT_PRINTF(1, 2);
 
 inline static void vprint_errormsg(const char* const fmt, va_list ap) {
 	// (v)snprintf returns the number that would have been written

--- a/ctest.h
+++ b/ctest.h
@@ -210,10 +210,10 @@ typedef int (*ctest_filter_func)(struct ctest*);
 
 CTEST(suite, test) { }
 
-inline static void vprint_errormsg(const char* const fmt, va_list ap) CTEST_IMPL_FORMAT_PRINTF(1, 0);
-inline static void print_errormsg(const char* const fmt, ...) CTEST_IMPL_FORMAT_PRINTF(1, 2);
+static void vprint_errormsg(const char* const fmt, va_list ap) CTEST_IMPL_FORMAT_PRINTF(1, 0);
+static void print_errormsg(const char* const fmt, ...) CTEST_IMPL_FORMAT_PRINTF(1, 2);
 
-inline static void vprint_errormsg(const char* const fmt, va_list ap) {
+static void vprint_errormsg(const char* const fmt, va_list ap) {
 	// (v)snprintf returns the number that would have been written
     const int ret = vsnprintf(ctest_errormsg, ctest_errorsize, fmt, ap);
     if (ret < 0) {
@@ -227,7 +227,7 @@ inline static void vprint_errormsg(const char* const fmt, va_list ap) {
     }
 }
 
-inline static void print_errormsg(const char* const fmt, ...) {
+static void print_errormsg(const char* const fmt, ...) {
     va_list argp;
     va_start(argp, fmt);
     vprint_errormsg(fmt, argp);

--- a/ctest.h
+++ b/ctest.h
@@ -40,6 +40,11 @@
 typedef void (*ctest_setup_func)(void*);
 typedef void (*ctest_teardown_func)(void*);
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
+#endif
+
 struct ctest {
     const char* ssname;  // suite name
     const char* ttname;  // test name
@@ -53,6 +58,10 @@ struct ctest {
 
     unsigned int magic;
 };
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
 
 #define CTEST_IMPL_NAME(name) ctest_##name
 #define CTEST_IMPL_FNAME(sname, tname) CTEST_IMPL_NAME(sname##_##tname##_run)
@@ -241,7 +250,7 @@ static void msg_start(const char* color, const char* title) {
     print_errormsg("  %s: ", title);
 }
 
-static void msg_end() {
+static void msg_end(void) {
     if (color_output) {
     	print_errormsg(ANSI_NORMAL);
     }
@@ -397,7 +406,7 @@ static int suite_filter(struct ctest* t) {
     return strncmp(suite_name, t->ssname, strlen(suite_name)) == 0;
 }
 
-static uint64_t getCurrentTime() {
+static uint64_t getCurrentTime(void) {
     struct timeval now;
     gettimeofday(&now, NULL);
     uint64_t now64 = (uint64_t) now.tv_sec;

--- a/ctest.h
+++ b/ctest.h
@@ -44,11 +44,12 @@ struct ctest {
     const char* ssname;  // suite name
     const char* ttname;  // test name
     void (*run)();
-    int skip;
 
     void* data;
     ctest_setup_func setup;
     ctest_teardown_func teardown;
+
+    int skip;
 
     unsigned int magic;
 };
@@ -59,9 +60,9 @@ struct ctest {
 
 #define CTEST_IMPL_MAGIC (0xdeadbeef)
 #ifdef __APPLE__
-#define CTEST_IMPL_SECTION __attribute__ ((used, section ("__DATA, .ctest")))
+#define CTEST_IMPL_SECTION __attribute__ ((used, section ("__DATA, .ctest"), aligned(1)))
 #else
-#define CTEST_IMPL_SECTION __attribute__ ((used, section (".ctest")))
+#define CTEST_IMPL_SECTION __attribute__ ((used, section (".ctest"), aligned(1)))
 #endif
 
 #define CTEST_IMPL_STRUCT(sname, tname, tskip, tdata, tsetup, tteardown) \
@@ -69,10 +70,10 @@ struct ctest {
         .ssname=#sname, \
         .ttname=#tname, \
         .run = CTEST_IMPL_FNAME(sname, tname), \
-        .skip = tskip, \
         .data = tdata, \
         .setup = (ctest_setup_func) tsetup, \
         .teardown = (ctest_teardown_func) tteardown, \
+        .skip = tskip, \
         .magic = CTEST_IMPL_MAGIC }
 
 #define CTEST_DATA(sname) struct CTEST_IMPL_NAME(sname##_data)

--- a/mytests.c
+++ b/mytests.c
@@ -28,19 +28,19 @@ CTEST_DATA(memtest) {
 
 // Optional setup function for suite, called before every test in suite
 CTEST_SETUP(memtest) {
-    CTEST_LOG("%s() data=%p buffer=%p", __func__, data, data->buffer);
+    CTEST_LOG("%s() data=%p buffer=%p", __func__, (void*)data, (void*)data->buffer);
     data->buffer = (unsigned char*)malloc(1024);
 }
 
 // Optional teardown function for suite, called after every test in suite
 CTEST_TEARDOWN(memtest) {
-    CTEST_LOG("%s() data=%p buffer=%p", __func__, data, data->buffer);
+    CTEST_LOG("%s() data=%p buffer=%p", __func__, (void*)data, (void*)data->buffer);
     if (data->buffer) free(data->buffer);
 }
 
 // These tests are called with the struct* (named data) as argument
 CTEST2(memtest, test1) {
-    CTEST_LOG("%s()  data=%p  buffer=%p", __func__, data, data->buffer);
+    CTEST_LOG("%s()  data=%p  buffer=%p", __func__, (void*)data, (void*)data->buffer);
 }
 
 CTEST2_SKIP(memtest, test3) {
@@ -49,7 +49,7 @@ CTEST2_SKIP(memtest, test3) {
 }
 
 CTEST2(memtest, test2) {
-    CTEST_LOG("%s()  data=%p  buffer=%p", __func__, data, data->buffer);
+    CTEST_LOG("%s()  data=%p  buffer=%p", __func__, (void*)data, (void*)data->buffer);
     
     ASSERT_FAIL();
 }

--- a/mytests.c
+++ b/mytests.c
@@ -44,6 +44,7 @@ CTEST2(memtest, test1) {
 }
 
 CTEST2_SKIP(memtest, test3) {
+    (void)data;
     ASSERT_FAIL();
 }
 
@@ -58,10 +59,13 @@ CTEST_DATA(fail) {};
 
 // Asserts can also be used in setup/teardown functions
 CTEST_SETUP(fail) {
+    (void)data;
     ASSERT_FAIL();
 }
 
-CTEST2(fail, test1) {}
+CTEST2(fail, test1) {
+    (void)data;
+}
 
 
 
@@ -71,10 +75,12 @@ CTEST_DATA(weaklinkage) {
 
 // This suite has data, but no setup/teardown
 CTEST2(weaklinkage, test1) {
+    (void)data;
     CTEST_LOG("%s()", __func__);
 }
 
 CTEST2(weaklinkage, test2) {
+    (void)data;
     CTEST_LOG("%s()", __func__);
 }
 
@@ -84,10 +90,12 @@ CTEST_DATA(nosetup) {
 };
 
 CTEST_TEARDOWN(nosetup) {
+    (void)data;
     CTEST_LOG("%s()", __func__);
 }
 
 CTEST2(nosetup, test1) {
+    (void)data;
     CTEST_LOG("%s()", __func__);
 }
 


### PR DESCRIPTION
I've tried to reduce the number of warnings reported, testing on Gentoo Linux amd64 (with Clang and GCC) and macOS 10.12 (with Clang from Xcode 8.2.1). When compiling internal tests with Clang (using `clang -Weverything main.c mytests.c -O3 -o test`), number of warnings went from 12 (main.c) + 46 (mytests.c) down to none (main.c) + 2 (mytests.c); GCC (using `gcc -Wall -Wextra main.c mytests.c -O3 -o test`) reported 7 warnings (in mytests.c only) before the changes and no warnings after.

Warnings still reported by Clang are in mytests.c and not directly related to ctest itself:

```
% clang -Weverything main.c mytests.c -o test                         
mytests.c:58:1: warning: empty struct has size 0 in C, size 1 in C++ [-Wc++-compat]
CTEST_DATA(fail) {};
^
./ctest.h:79:27: note: expanded from macro 'CTEST_DATA'
#define CTEST_DATA(sname) struct CTEST_IMPL_NAME(sname##_data)
                          ^
mytests.c:58:1: warning: empty struct is a GNU extension [-Wgnu-empty-struct]
./ctest.h:79:27: note: expanded from macro 'CTEST_DATA'
#define CTEST_DATA(sname) struct CTEST_IMPL_NAME(sname##_data)
                          ^
2 warnings generated.
```

Not exactly sure on the naming changes, so if you have other suggestions...