### PR TITLE
Remove weak linkage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,6 @@ UNAME=$(shell uname)
 CCFLAGS=-Wall -Wextra -Wconversion -Wredundant-decls -Wno-unused-parameter -O3
 CC=clang
 
-ifeq ($(UNAME), Darwin)
-LDFLAGS=-Wl,-flat_namespace,-undefined,dynamic_lookup
-endif
-
 all: test
 
 remake: clean all

--- a/ctest.h
+++ b/ctest.h
@@ -107,6 +107,9 @@ CTEST_IMPL_DIAG_POP()
     static void CTEST_IMPL_TEARDOWN_FNAME(sname)(struct CTEST_IMPL_DATA_SNAME(sname)* data)
 
 #define CTEST_DATA(sname) \
+    struct CTEST_IMPL_DATA_SNAME(sname); \
+    static void (*CTEST_IMPL_SETUP_FPNAME(sname))(struct CTEST_IMPL_DATA_SNAME(sname)*); \
+    static void (*CTEST_IMPL_TEARDOWN_FPNAME(sname))(struct CTEST_IMPL_DATA_SNAME(sname)*); \
     struct CTEST_IMPL_DATA_SNAME(sname)
 
 #define CTEST_IMPL_CTEST(sname, tname, tskip) \
@@ -117,10 +120,6 @@ CTEST_IMPL_DIAG_POP()
 #define CTEST_IMPL_CTEST2(sname, tname, tskip) \
     static struct CTEST_IMPL_DATA_SNAME(sname) CTEST_IMPL_DATA_TNAME(sname, tname); \
     static void CTEST_IMPL_FNAME(sname, tname)(struct CTEST_IMPL_DATA_SNAME(sname)* data); \
-    CTEST_IMPL_DIAG_PUSH_IGNORED(redundant-decls) \
-    static void (*CTEST_IMPL_SETUP_FPNAME(sname))(struct CTEST_IMPL_DATA_SNAME(sname)*); \
-    static void (*CTEST_IMPL_TEARDOWN_FPNAME(sname))(struct CTEST_IMPL_DATA_SNAME(sname)*); \
-    CTEST_IMPL_DIAG_POP() \
     CTEST_IMPL_STRUCT(sname, tname, tskip, &CTEST_IMPL_DATA_TNAME(sname, tname), &CTEST_IMPL_SETUP_FPNAME(sname), &CTEST_IMPL_TEARDOWN_FPNAME(sname)); \
     static void CTEST_IMPL_FNAME(sname, tname)(struct CTEST_IMPL_DATA_SNAME(sname)* data)
 

--- a/ctest.h
+++ b/ctest.h
@@ -31,7 +31,7 @@ typedef void (*ctest_teardown_func)(void*);
 #define CTEST_IMPL_PRAGMA(x) _Pragma (#x)
 
 #if defined(__GNUC__)
-#if (defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)))
+#if defined(__clang__) || __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)
 /* the GCC argument will work for both gcc and clang  */
 #define CTEST_IMPL_DIAG_PUSH_IGNORED(w) \
     CTEST_IMPL_PRAGMA(GCC diagnostic push) \

--- a/ctest.h
+++ b/ctest.h
@@ -40,10 +40,29 @@
 typedef void (*ctest_setup_func)(void*);
 typedef void (*ctest_teardown_func)(void*);
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstrict-prototypes"
+#define CTEST_IMPL_PRAGMA(x) _Pragma (#x)
+
+#if defined(__GNUC__)
+#if (defined(__clang__) || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 6)))
+/* the GCC argument will work for both gcc and clang  */
+#define CTEST_IMPL_DIAG_PUSH_IGNORED(w) \
+    CTEST_IMPL_PRAGMA(GCC diagnostic push) \
+    CTEST_IMPL_PRAGMA(GCC diagnostic ignored "-W" #w)
+#define CTEST_IMPL_DIAG_POP() \
+    CTEST_IMPL_PRAGMA(GCC diagnostic pop)
+#else
+/* the push/pop functionality wasn't in gcc until 4.6, fallback to "ignored"  */
+#define CTEST_IMPL_DIAG_PUSH_IGNORED(w) \
+    CTEST_IMPL_PRAGMA(GCC diagnostic ignored "-W" #w)
+#define CTEST_IMPL_DIAG_POP()
 #endif
+#else
+/* leave them out entirely for non-GNUC compilers  */
+#define CTEST_IMPL_DIAG_PUSH_IGNORED(w)
+#define CTEST_IMPL_DIAG_POP()
+#endif
+
+CTEST_IMPL_DIAG_PUSH_IGNORED(strict-prototypes)
 
 struct ctest {
     const char* ssname;  // suite name
@@ -59,9 +78,7 @@ struct ctest {
     unsigned int magic;
 };
 
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+CTEST_IMPL_DIAG_POP()
 
 #define CTEST_IMPL_NAME(name) ctest_##name
 #define CTEST_IMPL_FNAME(sname, tname) CTEST_IMPL_NAME(sname##_##tname##_run)
@@ -269,10 +286,7 @@ void CTEST_LOG(const char* fmt, ...)
     msg_end();
 }
 
-#ifdef __GNUC__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmissing-noreturn"
-#endif
+CTEST_IMPL_DIAG_PUSH_IGNORED(missing-noreturn)
 
 void CTEST_ERR(const char* fmt, ...)
 {
@@ -287,9 +301,7 @@ void CTEST_ERR(const char* fmt, ...)
     longjmp(ctest_err, 1);
 }
 
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
+CTEST_IMPL_DIAG_POP()
 
 void assert_str(const char* exp, const char*  real, const char* caller, int line) {
     if ((exp == NULL && real != NULL) ||


### PR DESCRIPTION
This patch aims to improve the portability of the library by replacing the usage of weak linking with a standard C approach involving an extra level of indirection and tentative definitions.

Ctest allows the user to leave the setup and/or teardown callbacks for a test suite undefined. This was previously implemented using weak symbols, so that undefined references to unimplemented callbacks became NULL pointers instead of linker errors. This approach hurts portability and introduces complexity since weak symbol handling is not standardized and differs across platforms. 

This patch implements an alternate approach. The CTEST2 macro now tentatively defines callback pointers and passes their addresses to the CTEST_IMPL_STRUCT macro. The CTEST_SETUP and CTEST_TEARDOWN macros complete the respective tentative definitions. This way, if the user defines CTEST_SETUP, *test->setup will point to the setup callback. If not, *test->setup will point to NULL. ctest_main now checks this extra level of indirection to determine whether to call the setup callback. The same follows for CTEST_TEARDOWN and *test->teardown.

I believe that there is no change in functionality, but please let me know if there is anything that weak-linking was providing that this approach does not.

This PR also includes some clean-up of the inline warning pragmas. This was done so that Wredeundant-decls could be momentarily toggled during the expansion of CTEST2.

Thanks to @mattkelly for introducing me to ctest and convincing me to push some of my local changes upstream. Love the library @bvdberg !