### PR TITLE
Enforce test ordering

### DIFF
--- a/ctest.h
+++ b/ctest.h
@@ -37,20 +37,19 @@
 #define CTEST_IMPL_COUNTER __LINE__
 #endif
 
-/* gcc and clang implement preprocessor-based hardening that replaces certain
- * pointer-problem-prone library functions with new ones that take additional
- * argument(s) if information about object size is available at compile-time.
- * Since we build a linker set out of statically-defined objects, we treat
- * pointers into the linker set as pointers into an ordinary array, but the
- * compiler has no idea that the memory is contiguous, so hardened library
- * functions that receive a pointer into the linker set will assert a buffer
- * overrun error if that function accesses past the end of the first item.
- * Therefore, we need to trick the compiler into not invoking these hardened
- * functions when we are passing them a pointer into the linker set.
+/* If `_FORTIFY_SOURCE` is non-zero, some compilers will transform certain
+ * pointer-problem-prone libc functions into hardened versions via preprocessor
+ * macros.  These hardened versions take additional parameters(s) with
+ * compile-time object size information.  Since we build a linker set out of
+ * statically-defined objects, we can treat linker set pointers as array
+ * pointers.  The trouble is, the compiler has no idea that the memory is
+ * contiguous, so hardened versions will assert a buffer overrun error if they
+ * access past the end of the first item.  Therefore, we need a means for
+ * disabling this transformation when dealing with linker set pointers.
  *
  * Luckily, since the mechanism is preprocessor-based, the solution is simple:
- * wrap the function name in parens so that e.g. memcpy does not become
- * __memcpy_chk during preprocessing.  */
+ * wrap the function name in parens so that e.g. `memcpy` does not become
+ * `__memcpy_chk` during preprocessing.  */
 #define CTEST_IMPL_UNFORTIFIED(f) (f)
 
 #include <inttypes.h> /* intmax_t, uintmax_t, PRI* */

--- a/ctest.h
+++ b/ctest.h
@@ -22,21 +22,6 @@
 #define CTEST_IMPL_FORMAT_PRINTF(a, b)
 #endif
 
-/* To enforce a total ordering on tests defined within a file, we can use the
- * non-C-standard-but-widely-implemented `__COUNTER__`.  This way, the tests
- * may be sorted in program definition order.  If `__COUNTER__` isn't available,
- * the C-standard `__LINE__` will have the same effect _most_ of the time.
- *
- * Notably, this fails when multiple `CTEST` expansions occur on the same line.
- * That might seem like an insane thing to do, but could easily happen if
- * multiple `CTEST` invocations occur in a macro.  With `__LINE__`, the ordering
- * of colinear test cases is not defined.  Oh well...  */
-#if defined(__COUNTER__)
-#define CTEST_IMPL_COUNTER __COUNTER__
-#else
-#define CTEST_IMPL_COUNTER __LINE__
-#endif
-
 /* If `_FORTIFY_SOURCE` is non-zero, some compilers will transform certain
  * pointer-problem-prone libc functions into hardened versions via preprocessor
  * macros.  These hardened versions take additional parameters(s) with
@@ -91,10 +76,6 @@ struct ctest {
     ctest_setup_func* setup;
     ctest_teardown_func* teardown;
 
-    // for sorting purposes
-    const char* file;
-    int counter;
-
     int skip;
 
     unsigned int magic;
@@ -129,8 +110,6 @@ CTEST_IMPL_DIAG_POP()
         .data = tdata, \
         .setup = tsetup, \
         .teardown = tteardown, \
-        .file = __FILE__, \
-        .counter = CTEST_IMPL_COUNTER, \
         .skip = tskip, \
         .magic = CTEST_IMPL_MAGIC }
 
@@ -471,8 +450,7 @@ static int ctest_comparator(const void* p1, const void* p2)
 
 #define CTEST_IMPL_TRY(expr) do { if ((rc = (expr)) != 0) return rc; } while (0)
     CTEST_IMPL_TRY(strcmp(test1->ssname, test2->ssname));
-    CTEST_IMPL_TRY(strcmp(test1->file, test2->file));
-    CTEST_IMPL_TRY(test1->counter - test2->counter);
+    CTEST_IMPL_TRY(strcmp(test1->ttname, test2->ttname));
 #undef CTEST_IMPL_TRY
 
     return rc;

--- a/ctest.h
+++ b/ctest.h
@@ -51,11 +51,7 @@
  * Luckily, since the mechanism is preprocessor-based, the solution is simple:
  * wrap the function name in parens so that e.g. memcpy does not become
  * __memcpy_chk during preprocessing.  */
-#if _FORTIFY_SOURCE > 0
 #define CTEST_IMPL_UNFORTIFIED(f) (f)
-#else
-#define CTEST_IMPL_UNFORTIFIED(f) f
-#endif
 
 #include <inttypes.h> /* intmax_t, uintmax_t, PRI* */
 #include <stddef.h> /* size_t */

--- a/ctest.h
+++ b/ctest.h
@@ -74,8 +74,10 @@ CTEST_IMPL_DIAG_POP()
 #define CTEST_IMPL_DATA_SNAME(sname) CTEST_IMPL_NAME(sname##_data)
 #define CTEST_IMPL_DATA_TNAME(sname, tname) CTEST_IMPL_NAME(sname##_##tname##_data)
 #define CTEST_IMPL_SETUP_FNAME(sname) CTEST_IMPL_NAME(sname##_setup)
+#define CTEST_IMPL_SETUP_SHIM_FNAME(sname) CTEST_IMPL_NAME(sname##_setup_shim)
 #define CTEST_IMPL_SETUP_FPNAME(sname) CTEST_IMPL_NAME(sname##_setup_ptr)
 #define CTEST_IMPL_TEARDOWN_FNAME(sname) CTEST_IMPL_NAME(sname##_teardown)
+#define CTEST_IMPL_TEARDOWN_SHIM_FNAME(sname) CTEST_IMPL_NAME(sname##_teardown_shim)
 #define CTEST_IMPL_TEARDOWN_FPNAME(sname) CTEST_IMPL_NAME(sname##_teardown_ptr)
 
 #define CTEST_IMPL_MAGIC (0xdeadbeef)
@@ -91,25 +93,32 @@ CTEST_IMPL_DIAG_POP()
         .ttname=#tname, \
         .run = CTEST_IMPL_FNAME(sname, tname), \
         .data = tdata, \
-        .setup = (ctest_setup_func*) tsetup, \
-        .teardown = (ctest_teardown_func*) tteardown, \
+        .setup = tsetup, \
+        .teardown = tteardown, \
         .skip = tskip, \
         .magic = CTEST_IMPL_MAGIC }
 
 #define CTEST_SETUP(sname) \
-    static void CTEST_IMPL_SETUP_FNAME(sname)(struct CTEST_IMPL_DATA_SNAME(sname)* data); \
-    static void (*CTEST_IMPL_SETUP_FPNAME(sname))(struct CTEST_IMPL_DATA_SNAME(sname)*) = &CTEST_IMPL_SETUP_FNAME(sname); \
+    static void CTEST_IMPL_SETUP_FNAME(sname)(struct CTEST_IMPL_DATA_SNAME(sname)*); \
+    static void CTEST_IMPL_SETUP_SHIM_FNAME(sname)(void *data) \
+    { \
+        CTEST_IMPL_SETUP_FNAME(sname)((struct CTEST_IMPL_DATA_SNAME(sname)*)data); \
+    } \
+    static ctest_setup_func CTEST_IMPL_SETUP_FPNAME(sname) = &CTEST_IMPL_SETUP_SHIM_FNAME(sname); \
     static void CTEST_IMPL_SETUP_FNAME(sname)(struct CTEST_IMPL_DATA_SNAME(sname)* data)
 
 #define CTEST_TEARDOWN(sname) \
-    static void CTEST_IMPL_TEARDOWN_FNAME(sname)(struct CTEST_IMPL_DATA_SNAME(sname)* data); \
-    static void (*CTEST_IMPL_TEARDOWN_FPNAME(sname))(struct CTEST_IMPL_DATA_SNAME(sname)*) = &CTEST_IMPL_TEARDOWN_FNAME(sname); \
+    static void CTEST_IMPL_TEARDOWN_FNAME(sname)(struct CTEST_IMPL_DATA_SNAME(sname)*); \
+    static void CTEST_IMPL_TEARDOWN_SHIM_FNAME(sname)(void *data) \
+    { \
+        CTEST_IMPL_TEARDOWN_FNAME(sname)((struct CTEST_IMPL_DATA_SNAME(sname)*)data); \
+    } \
+    static ctest_teardown_func CTEST_IMPL_TEARDOWN_FPNAME(sname) = &CTEST_IMPL_TEARDOWN_SHIM_FNAME(sname); \
     static void CTEST_IMPL_TEARDOWN_FNAME(sname)(struct CTEST_IMPL_DATA_SNAME(sname)* data)
 
 #define CTEST_DATA(sname) \
-    struct CTEST_IMPL_DATA_SNAME(sname); \
-    static void (*CTEST_IMPL_SETUP_FPNAME(sname))(struct CTEST_IMPL_DATA_SNAME(sname)*); \
-    static void (*CTEST_IMPL_TEARDOWN_FPNAME(sname))(struct CTEST_IMPL_DATA_SNAME(sname)*); \
+    static ctest_setup_func CTEST_IMPL_SETUP_FPNAME(sname); \
+    static ctest_teardown_func CTEST_IMPL_TEARDOWN_FPNAME(sname); \
     struct CTEST_IMPL_DATA_SNAME(sname)
 
 #define CTEST_IMPL_CTEST(sname, tname, tskip) \
@@ -119,7 +128,7 @@ CTEST_IMPL_DIAG_POP()
 
 #define CTEST_IMPL_CTEST2(sname, tname, tskip) \
     static struct CTEST_IMPL_DATA_SNAME(sname) CTEST_IMPL_DATA_TNAME(sname, tname); \
-    static void CTEST_IMPL_FNAME(sname, tname)(struct CTEST_IMPL_DATA_SNAME(sname)* data); \
+    static void CTEST_IMPL_FNAME(sname, tname)(struct CTEST_IMPL_DATA_SNAME(sname)*); \
     CTEST_IMPL_STRUCT(sname, tname, tskip, &CTEST_IMPL_DATA_TNAME(sname, tname), &CTEST_IMPL_SETUP_FPNAME(sname), &CTEST_IMPL_TEARDOWN_FPNAME(sname)); \
     static void CTEST_IMPL_FNAME(sname, tname)(struct CTEST_IMPL_DATA_SNAME(sname)* data)
 


### PR DESCRIPTION
This PR enforces that test cases run in a predictable order. The ordering is as follows:

* Tests in different suites are ordered lexicographically by suite name
* Tests in the same suite and different source files are ordered lexicographically by source file name
* Tests in the same suite and same file are ordered by the relative positions of their definitions.

This requires code changes because, in general, ordering on linker sets is not well-defined. In fact, gcc is known to [reorder top-level definitions in opposite order when compiling with optimizations](https://gcc.gnu.org/ml/gcc-help/2013-10/msg00047.html). The solution has been implemented by simply sorting the linker set in ctest_main with `qsort` based on a newly-defined callback `ctest_comparator`.

This patch has the possibility of breaking existing `ctest.h` user programs. This is because the act of sorting the linker set changes the content pointed to by the lvalues of the `struct ctest` instances that are defined by the `CTEST` macro. More concretely, `ctest_suite_test` may no longer point to the structure defined in `CTEST(suite, test)` after we have performed the sort. If users are referencing these structs by name anywhere in their program code, their programs may break. In my opinion, it is acceptable to break those programs since the underlying `struct ctest` instances should be considered private implementation details of `ctest.h`, and thus subject to change without warning. If you don't think this is acceptable, we can try a different approach. One option would be to allocate an additional array of pointers to `struct ctest` and sort those pointers instead of the structures themselves. Please let me know which you prefer.

This PR also includes some clean-up of undefined behavior caused by the calling of casted function pointers. This was unlikely to have been causing problems, since we were casting functions that take typed pointers to functions that take void pointers, so any sane compiler is likely to produce the same code either way. I just prefer to be get rid of UB when it doesn't cost us anything...