### PR TITLE
MSVC support

### DIFF
--- a/ctest.h
+++ b/ctest.h
@@ -425,7 +425,7 @@ static void color_print(const char* color, const char* text) {
 static void sighandler(int signum)
 {
     char msg[128];
-    sprintf(msg, "[SIGNAL %d: %s]", signum, sys_siglist[signum]);
+    snprintf(msg, sizeof(msg), "[SIGNAL %d: %s]", signum, sys_siglist[signum]);
     color_print(ANSI_BRED, msg);
     fflush(stdout);
 
@@ -523,7 +523,7 @@ int ctest_main(int argc, const char *argv[])
 
     const char* color = (num_fail) ? ANSI_BRED : ANSI_GREEN;
     char results[80];
-    sprintf(results, "RESULTS: %d tests (%d ok, %d failed, %d skipped) ran in %" PRIu64 " ms", total, num_ok, num_fail, num_skip, (t2 - t1)/1000);
+    snprintf(results, sizeof(results), "RESULTS: %d tests (%d ok, %d failed, %d skipped) ran in %" PRIu64 " ms", total, num_ok, num_fail, num_skip, (t2 - t1)/1000);
     color_print(color, results);
     return num_fail;
 }

--- a/main.c
+++ b/main.c
@@ -3,7 +3,7 @@
 #define CTEST_MAIN
 
 // uncomment lines below to enable/disable features. See README.md for details
-#define CTEST_SEGFAULT
+//#define CTEST_SEGFAULT
 //#define CTEST_NO_COLORS
 //#define CTEST_COLOR_OK
 

--- a/mytests.c
+++ b/mytests.c
@@ -1,10 +1,18 @@
-#include <unistd.h>
 #include <stdlib.h>
+
+#ifndef _WIN32
+#include <unistd.h>
+#define MSLEEP(ms) usleep((ms) * 1000)
+#else
+#include <windows.h>
+#define MSLEEP(ms) Sleep(ms)
+#endif
+
 #include "ctest.h"
 
 // basic test without setup/teardown
 CTEST(suite1, test1) {
-    usleep(2000);
+    MSLEEP(2);
 }
 
 // there are many different ASSERT macro's (see ctest.h)

--- a/mytests.c
+++ b/mytests.c
@@ -124,7 +124,7 @@ CTEST(ctest, test_assert_interval) {
 
 CTEST(ctest, test_assert_null) {
     ASSERT_NULL(NULL);
-    ASSERT_NULL((void*)0xdeadbeef);
+    ASSERT_NULL((void*)(intptr_t)0xdeadbeef);
 }
 
 CTEST(ctest, test_assert_not_null_const) {
@@ -132,7 +132,7 @@ CTEST(ctest, test_assert_not_null_const) {
 }
 
 CTEST(ctest, test_assert_not_null) {
-    ASSERT_NOT_NULL((void*)0xdeadbeef);
+    ASSERT_NOT_NULL((void*)(intptr_t)0xdeadbeef);
     ASSERT_NOT_NULL(NULL);
 }
 

--- a/mytests.c
+++ b/mytests.c
@@ -54,7 +54,9 @@ CTEST2(memtest, test2) {
 }
 
 
-CTEST_DATA(fail) {};
+CTEST_DATA(fail) {
+    int unused;
+};
 
 // Asserts can also be used in setup/teardown functions
 CTEST_SETUP(fail) {


### PR DESCRIPTION
The changes here are based in part on #29 for which I thank @uael. This is a minimal set of changes needed to make use of ctest with recent versions of MSVC, without any warnings even on `/W4`.

Despite the fact that I have omitted Travis/AppVeyor stuff here (compared to #29), I do second the need in some kind of CI to make sure all the supported platforms are in fact supported.