### PR TITLE
Make signal handler only call async-signal-safe functions

### DIFF
--- a/ctest.h
+++ b/ctest.h
@@ -436,10 +436,12 @@ static void color_print(const char* color, const char* text) {
 #include <signal.h>
 static void sighandler(int signum)
 {
-    char msg[128];
-    snprintf(msg, sizeof(msg), "[SIGNAL %d: %s]", signum, sys_siglist[signum]);
-    color_print(ANSI_BRED, msg);
-    fflush(stdout);
+    if (color_output)
+        const char *msg = ANSI_BRED "[SIGSEGV: Segmentation fault]" ANSI_NORMAL "\n";
+    else
+        const char *msg = "[SIGSEGV: Segmentation fault]\n";
+
+    write(STDOUT_FILENO, msg, strlen(msg));
 
     /* "Unregister" the signal handler and send the signal back to the process
      * so it can terminate as expected */


### PR DESCRIPTION
Signal handlers should only call async-signal-safe functions, as noted in `man signal-safety` (see relevant excerpt below). This rather simple patch makes the `sighandler()` function used to handle `SIGSEGV` compliant by removing any call to not async-signal-safe functions (such as `printf()` and similars).

Since this function is only used as signal handler for `SIGSEGV`, there's no need to do much pretty-printing, the only signal that can be received is `SIGSEGV`, so I just substituted the three calls to `snprintf()`, `color_print()` and `fflush()` with a single `write()` of a fixed message.


From [`man signal-safety`](http://man7.org/linux/man-pages/man7/signal-safety.7.html):

> An  async-signal-safe  function  is one that can be safely called from within a signal handler.  Many functions are not async-signal-safe.  In particular, nonreentrant functions are generally unsafe to call from a signal handler.
> 
> The kinds of issues that render a function unsafe can be quickly understood when one considers  the  implementation  of the stdio library, all of whose functions are not async-signal-safe.
> 
> When performing buffered I/O on a file, the stdio functions must maintain a statically allocated data buffer along with associated counters and indexes (or pointers) that record the amount of data and the current position  in  the  buffer. Suppose  that  the  main  program is in the middle of a call to a stdio function such as printf(3) where the buffer and associated variables have been partially updated.  If, at that moment, the program is interrupted by a  signal  handler that  also  calls  printf(3),  then  the second call to printf(3) will operate on inconsistent data, with unpredictable results.
> 
> To avoid problems with unsafe functions, there are two possible choices:
> 
> 1. Ensure that (a) the signal handler calls only async-signal-safe functions, and (b)  the  signal  handler  itself  is reentrant with respect to global variables in the main program.
> 
> 2. Block signal delivery in the main program when calling functions that are unsafe or operating on global data that is also accessed by the signal handler.
> 
> Generally, the second choice is difficult in programs of any complexity, so the first choice is taken.

The choice taken here is the first one.