### PR TITLE
Add basic C++ support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.o
 tags
 test
+test++

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,26 @@ UNAME=$(shell uname)
 
 CCFLAGS=-Wall -Wextra -Wconversion -Wredundant-decls -Wshadow -Wno-unused-parameter -O3
 CC=clang
+CXX=clang++
 
-all: test
+all: test test++
 
 remake: clean all
 
-%.o: %.c ctest.h
+%.cpp: %.c
+	ln -fs $< $@
+
+%.c.o: %.c ctest.h
 	$(CC) $(CCFLAGS) -c -o $@ $<
 
-test: main.o ctest.h mytests.o
-	$(CC) $(LDFLAGS) main.o mytests.o -o test
+%.cpp.o: %.cpp ctest.h
+	$(CXX) $(CCFLAGS) -c -o $@ $<
+
+test: main.c.o ctest.h mytests.c.o
+	$(CC) $(LDFLAGS) main.c.o mytests.c.o -o test
+
+test++: main.cpp.o ctest.h mytests.cpp.o
+	$(CXX) $(LDFLAGS) main.cpp.o mytests.cpp.o -o test++
 
 clean:
-	rm -f test *.o
-
+	rm -f test test++ *.o

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-UNAME=$(shell uname)
-
 CCFLAGS=-Wall -Wextra -Wconversion -Wredundant-decls -Wshadow -Wno-unused-parameter -O3
 CC=clang
 CXX=clang++

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CTEST
 
-ctest is a unit test framework for software written in C.
+ctest is a unit test framework for software written in C/C++.
 
 Features:
 * adding tests with minimal hassle (no manual adding to suites or testlists!)


### PR DESCRIPTION
This commit adds C++ support with the following modifications:
- Remove the use of C-only features including designated initializers
  and non-strict prototypes.
- Add spaces between literals and string macros to silence the C++-only
  -Wliteral-suffix warning.
- Conditionally use template specialization instead of tentative
  definitions to implement optional setup/teardown functions.

Note that no C++-specific features have been added.  The goal of this
commit is to simply enable compiling in C++ mode.