### PR TITLE
Fix detect test functions

### DIFF
--- a/ctest.h
+++ b/ctest.h
@@ -543,7 +543,7 @@ __attribute__((no_sanitize_address)) int ctest_main(int argc, const char *argv[]
             magic_end = m;
 
     static struct ctest* test;
-        for (m = magic_begin; m <= magic_end; ++m) {
+    for (m = magic_begin; m <= magic_end; ++m) {
         while (*m != CTEST_IMPL_MAGIC) ++m;
         test = CTEST_CONTAINER_OF(m, struct ctest, magic);
         if (test == &CTEST_IMPL_TNAME(suite, test)) continue;


### PR DESCRIPTION
This fixes the detection of test-functions (makes it more robust).
The strides are in general not constant between each ctest struct stored in memory, so we need to search specifically for the magic number.

With TinyC https://repo.or.cz/tinycc.git on linux, the stride is mostly 14 ints between each entry, but sometimes 16 and 18. On other platforms it is always 14 ints.
It now searches 8 ints beyond the ctest struct size, which is double of extra stride sometimes observed with TinyC. Both the current and this search is UB as it accesses memory outside the storage,
but works well in practice on most platforms.