### PR TITLE
Fix Alignment for clang on Mac >= 14.5

### DIFF
--- a/ctest.h
+++ b/ctest.h
@@ -90,7 +90,7 @@ struct ctest {
 
 #define CTEST_IMPL_MAGIC (0xdeadbeef)
 #ifdef __APPLE__
-#define CTEST_IMPL_SECTION __attribute__ ((used, section ("__DATA, .ctest"), aligned(1)))
+#define CTEST_IMPL_SECTION __attribute__ ((used, section ("__DATA, .ctest"), aligned(8)))
 #else
 #define CTEST_IMPL_SECTION __attribute__ ((used, section (".ctest"), aligned(1)))
 #endif


### PR DESCRIPTION
github.com/bvdberg/ctest/issues/56